### PR TITLE
Add WebDriver UI tests for Editor

### DIFF
--- a/tests/EditorPage.php
+++ b/tests/EditorPage.php
@@ -1,0 +1,62 @@
+<?php
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+class EditorPage {
+
+  public static $session;
+
+  public function __construct($browser_session){
+	  self::$session = $browser_session;
+  }
+
+  public function go_to_editor(){
+
+    self::$session->open("http://parapara-editor.mozlabs.jp/test");
+    //$this->assertEquals(self::$session->title(), "パラパラアニメーション");
+  }
+
+  public function centre_mouse_on_canvas(){
+
+    // TODO this doesn't work as well as it should
+  	$workspace = self::$session->element('tag name', 'rect');
+    $workspace_size = $workspace->size();
+	  $centre['x'] = (int)($workspace_size['width'] * 0.5);
+	  $centre['y'] = (int)($workspace_size['height'] * 0.5);
+
+    // move to a space within the canvas
+    self::$session->moveto(array('element' => $workspace->getID(), 
+      'xoffset' => $centre['x'], 'yoffset' => $centre['y']));
+  }
+
+  public function draw_a_path($x_offset, $y_offset){
+
+    self::$session->buttondown("");
+    self::$session->moveto(array('xoffset' => $x_offset, 
+      'yoffset' => $y_offset));
+    self::$session->buttonup("");
+  }
+
+  public function draw_a_circle(){
+
+    self::$session->click();
+    // wait for poly to turn into a circle
+    sleep(1);
+  }
+
+  public function select_delete_tool(){
+
+    // Get picker and its size, calculate the position of the eraser
+    $picker = self::$session->element("id", "picker");
+    $picker_size = $picker->size();
+
+    $eraser['x'] = (int)($picker_size['width'] * 0.33);
+    $eraser['y'] = (int)($picker_size['height'] * 0.8);
+
+    self::$session->moveto(array('element' => $picker->getID(), 
+      'xoffset' => $eraser['x'], 'yoffset' => $eraser['y']));
+    self::$session->click();
+  }
+
+}

--- a/tests/README
+++ b/tests/README
@@ -1,0 +1,38 @@
+Parapara UI test suite 
+======================
+
+Coverage:
+---------
+Editor: drawing a path, circle and deleting them.
+Wall: none
+
+Software Prerequisites:
+-----------------------
+- phpunit (unit testing framework): http://www.phpunit.de/
+- php-webdriver (php language bindings for Selenium WebDriver): https://github.com/Element-34/php-webdriver
+- Java/selenium standalone server (browser API): http://code.google.com/p/selenium/downloads/list
+- Windows and Firefox
+
+Setting up the Selenium Server:
+-------------------------------
+The Selenium Server sits inbetween the test code and the browser. It can direct commands to several browsers at once.
+
+After downloading the selenium-server-standalone-x.jar, run from a command line:
+java -jar selenium-server-standalone-x.jar 
+Selenium will be able to locate the Firefox binary if it is in a default location
+
+If you have Firefox in a non-standard location use:
+java -jar selenium-server-standalone-x.jar -Dwebdriver.firefox.bin="C:\path\to\Firefox"
+
+Running the tests:
+------------------
+From terminal/command line run:
+phpunit SvgCanvasTest.php
+
+The tests will send a command to the Selenium Server to start a browser session and perform the tests.
+Until [this bug][https://bugzilla.mozilla.org/show_bug.cgi?id=702605] is resolved you will need to keep the mouse cursor over the Firefox window while the test is running. Sorry about that!
+
+[Optional]
+Setup a Selenium Grid/Server to facilitate cross-browser testing.
+If this Grid is on a separate machine, modify the config.inc file to point to the IP address of the grid.
+A quick way to get started with a Selenium Grid is to use the Web QA team's Grid framework

--- a/tests/SvgDrawTest.php
+++ b/tests/SvgDrawTest.php
@@ -1,0 +1,86 @@
+<?php
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+require_once('TestBase.php');
+require_once('EditorPage.php');
+
+class SvgDrawTest extends TestBase {
+
+  public function test_draw_a_path() {
+
+    $editor_page = new EditorPage(self::$session);
+    $editor_page->go_to_editor();
+
+    $editor_page->centre_mouse_on_canvas();
+
+    $editor_page->draw_a_path(50, 50);
+
+    $path = self::$session->element('css selector', 'g#parapara g.frame path');
+    $this->assertTrue($path->displayed());
+  }
+
+  public function test_draw_a_circle() {
+
+    $editor_page = new EditorPage(self::$session);
+    $editor_page->go_to_editor();
+
+    $editor_page->centre_mouse_on_canvas();
+
+    $editor_page->draw_a_circle();
+
+    $circle = self::$session->element('css selector', 'g#parapara g.frame circle');
+    $expected_r = '4';
+
+    $this->assertTrue($circle->displayed());
+    $this->assertEquals($circle->attribute('r'), $expected_r);
+  }
+
+  public function test_delete_path() {
+
+    $editor_page = new EditorPage(self::$session);
+    $editor_page->go_to_editor();
+
+    $editor_page->centre_mouse_on_canvas();
+
+    $editor_page->draw_a_path(50, 50);
+
+    // check the path is present before we proceed
+    $this->assertTrue(self::$session
+      ->element('css selector', 'g.frame path')->displayed());
+
+    $editor_page->select_delete_tool();
+
+    $editor_page->centre_mouse_on_canvas();
+
+    $editor_page->draw_a_path(50, 50);
+    
+    // check that there are 0 paths or circles on the canvas
+    $this->assertEquals(0, 
+      count(self::$session->elements('css selector', 'g.frame *')));
+  }
+
+  public function test_delete_circle() {
+
+    $editor_page = new EditorPage(self::$session);
+    $editor_page->go_to_editor();
+
+    $editor_page->centre_mouse_on_canvas();
+
+    $editor_page->draw_a_circle();
+
+    // check the circle is present before we proceed
+    $this->assertTrue(self::$session->element('css selector', 'g.frame circle')->displayed());
+
+    $editor_page->select_delete_tool();
+
+    $editor_page->centre_mouse_on_canvas();
+
+    $editor_page->draw_a_circle();
+
+    // check that there are 0 paths or circles on the canvas
+    $this->assertEquals(0, 
+      count(self::$session->elements('css selector', 'g.frame *')));
+  }
+}

--- a/tests/TestBase.php
+++ b/tests/TestBase.php
@@ -1,0 +1,33 @@
+<?php
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+require_once('PHPWebDriver/WebDriver.php');
+require_once("config.inc");
+
+class TestBase extends PHPUnit_Framework_TestCase {
+
+
+    protected static $session;
+
+    // Will run before every test and set up a browser instance
+    public function setUp() {
+	global $config;
+	$host = 'http://%s:%s/wd/hub';
+	$host = sprintf($host, $config['webdriver']['host'], $config['webdriver']['port']);
+
+	// Pass in the host if you would like to run over a Selenium Server/Grid
+	$driver = new PHPWebDriver_WebDriver($host);
+
+	// Desired capabilities refer to browser version, platform and other settings
+	$desired_capabilities = $config['webdriver'];
+	self::$session = $driver->session($config['webdriver']['browserName'], $desired_capabilities);
+	self::$session->implicitlyWait(5);
+    }
+
+    // Will run after every test and close the browser
+    public function tearDown() {
+        self::$session->close();
+    }
+}

--- a/tests/ViewportSizeTest.php
+++ b/tests/ViewportSizeTest.php
@@ -1,0 +1,60 @@
+<?php
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+require_once('TestBase.php');
+require_once('EditorPage.php');
+
+class ViewportSizeTest extends TestBase {
+
+  // these tests check the responsiveness of the page to the window size
+
+  protected static $portrait_size = array('width' => 360, 'height' => 640);
+  protected static $landscape_size = array('width' => 640, 'height' => 360);
+
+  public function test_resize_to_tablet_portrait(){
+
+    $editor_page = new EditorPage(self::$session);
+    $editor_page::$session->window()->postSize(self::$portrait_size);
+
+    $editor_page->go_to_editor();
+
+    $filmstrip_location = $editor_page::$session
+      ->element("id", "filmstrip")->location();
+    $toolbox_location = $editor_page::$session
+      ->element("css selector", "div.tool-box")->location();
+    $window_size = $editor_page::$session->window()->size();
+
+    // check that at this size the filmstrip is located at (0,0)
+    $this->assertEquals(0, $filmstrip_location['x']);
+    $this->assertEquals(0, $filmstrip_location['y']);
+
+    // check that the toolbox is located in the bottom half of the window
+    $this->assertEquals(0, $toolbox_location['x']);
+    $this->assertGreaterThan((int)($window_size['height']/2),
+      $toolbox_location['y']);
+  }
+
+  public function test_resize_to_tablet_landscape(){
+
+    $editor_page = new EditorPage(self::$session);
+    $editor_page::$session->window()->postSize(self::$landscape_size);
+
+    $editor_page->go_to_editor();
+
+    $filmstrip_location = $editor_page::$session
+      ->element("id", "filmstrip")->location();
+    $toolbox = $editor_page::$session->element("css selector", "div.tool-box");
+    $toolbox_location = $toolbox->location();
+    $toolbox_size = $toolbox->size();
+
+    // check that at this size the filmstrip is located at the top
+    $this->assertEquals($toolbox_size['width'], $filmstrip_location['x']);
+    $this->assertEquals(0, $filmstrip_location['y']);
+
+    // check that the toolbox is located at (0,0)
+    $this->assertEquals(0, $toolbox_location['x']);
+    $this->assertEquals(0, $toolbox_location['y']);
+  }
+}

--- a/tests/config.inc.sample
+++ b/tests/config.inc.sample
@@ -1,0 +1,18 @@
+<?php
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+$config = array(
+  'webdriver' => array(
+    // 127.0.0.1 for a local selenium standalone server
+    'host' => '127.0.0.1',
+    'port' => '4444',
+    // browser desired capabilities
+    'browserName' => 'firefox',
+    'version' => '14',
+    'platform' => 'WINDOWS'
+  ),
+  'editor_url' => "http://parapara-editor.mozlabs.jp/test"
+);
+?>


### PR DESCRIPTION
Here is a small base/proof of concept for UI WebDriver tests against the パラパラ editor.

Test cases:
- Draw a line
- Draw a line and delete it
- Draw a circle
- Draw a circle and delete it
- Resize window to portrait tablet size and assert position of toolbox
- Resize window to landscape tablet size and assert position of toolbox

Some issues are:
- Must be run on Windows or Linux and have the mouse over the Firefox window when the tests starts or for IE, the mouse outside the browser window!
- Difficulty in installing phpunit, php-webdriver and their dependencies creates a bit of difficulty getting started, but I have tried to cover as much of this as I can in the Readme.
- Unable to access the shadow DOM inside the **< object >** which makes clicking on the pencil and eraser objects in the toolbox or film strip quite difficult and unreliable. I have spoken to the WebDriver devs about this and they said it would be possible to do in the future but SVG/Shadow DOM won't be put into WebDriver until there is sufficient demand.

がんばって～！
